### PR TITLE
[Task] Remove Device from Vault (Mobile/Compose Implementation)

### DIFF
--- a/composeApp/src/androidMain/kotlin/core/StringProvider.android.kt
+++ b/composeApp/src/androidMain/kotlin/core/StringProvider.android.kt
@@ -38,5 +38,9 @@ class StringProviderAndroid(private val context: Context) : StringProviderInterf
     override fun nameOccupiedJoinPrompt() = s(Res.string.name_occupied_join_prompt)
     override fun recoverPendingExists() = s(Res.string.recoverPendingExists)
     override fun recoverRequestSent() = s(Res.string.recoverRequestSent)
+    override fun removeDeviceSuccess() = s(Res.string.deviceRemovedSuccess)
+    override fun removeDeviceSelfError() = s(Res.string.removeDeviceSelfError)
+    override fun removeDeviceLastMemberError() = s(Res.string.removeDeviceLastMemberError)
+    override fun removeDeviceGenericError() = s(Res.string.removeDeviceGenericError)
 }
 

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -115,6 +115,12 @@
     <string name = "backup_choose_path_warning">Если вы не укажите путь, ваши данные будут утеряны при деинсталяции приложения</string>
     <string name = "ok">Ок</string>
     <string name = "currentDevice">Текущее устройство</string>
+    <string name = "removeDeviceConfirmTitle">Удалить девайс?</string>
+    <string name = "removeDeviceConfirmMessage">Вы действительно хотите удалить %1 со всех ваших устройств?</string>
+    <string name = "deviceRemovedSuccess">Девайс успешно удален</string>
+    <string name = "removeDeviceSelfError">Нельзя удалить текущее устройство</string>
+    <string name = "removeDeviceLastMemberError">Нельзя удалить последнее устройство в хранилище</string>
+    <string name = "removeDeviceGenericError">Не удалось удалить устройство</string>
     <string name = "wanna_recover">Показать ваш секрет?</string>
     <string name = "device_ui_category_android">Android</string>
     <string name = "device_ui_category_iphone">iPhone</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -115,6 +115,12 @@
     <string name = "backup_choose_path_warning">If you do not choose a path, your data may be lost when the app is uninstalled</string>
     <string name = "ok">Ok</string>
     <string name = "currentDevice">Current device</string>
+    <string name = "removeDeviceConfirmTitle">Remove device?</string>
+    <string name = "removeDeviceConfirmMessage">Do you really want to remove %1 from all your devices?</string>
+    <string name = "deviceRemovedSuccess">Device removed successfully</string>
+    <string name = "removeDeviceSelfError">You cannot remove the current device</string>
+    <string name = "removeDeviceLastMemberError">You cannot remove the last device in the vault</string>
+    <string name = "removeDeviceGenericError">Failed to remove device</string>
     <string name = "wanna_recover">Wanna show the secret?</string>
     <string name = "device_ui_category_android">Android</string>
     <string name = "device_ui_category_iphone">iPhone</string>

--- a/composeApp/src/commonMain/kotlin/core/StringProviderInterface.kt
+++ b/composeApp/src/commonMain/kotlin/core/StringProviderInterface.kt
@@ -29,5 +29,8 @@ interface StringProviderInterface {
     fun nameOccupiedJoinPrompt(): String
     fun recoverPendingExists(): String
     fun recoverRequestSent(): String
+    fun removeDeviceSuccess(): String
+    fun removeDeviceSelfError(): String
+    fun removeDeviceLastMemberError(): String
+    fun removeDeviceGenericError(): String
 }
-

--- a/composeApp/src/commonMain/kotlin/ui/scenes/devicesscreen/DevicesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/scenes/devicesscreen/DevicesScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -26,7 +28,8 @@ import androidx.compose.ui.zIndex
 import cafe.adriel.voyager.core.screen.Screen
 import kotlinproject.composeapp.generated.resources.Res
 import kotlinproject.composeapp.generated.resources.devicesList
-import kotlinproject.composeapp.generated.resources.biometric_error
+import kotlinproject.composeapp.generated.resources.removeDeviceConfirmMessage
+import kotlinproject.composeapp.generated.resources.removeDeviceConfirmTitle
 import models.appInternalModels.DeviceStatus
 import org.koin.compose.viewmodel.koinViewModel
 import core.AppColors
@@ -43,9 +46,12 @@ class DevicesScreen : Screen {
         val viewModel: DevicesScreenViewModel = koinViewModel()
         val devices by viewModel.devicesList.collectAsState()
         val isLoading by viewModel.isLoading.collectAsState()
+        val isRemoving by viewModel.isRemoving.collectAsState()
 
         var isDialogVisible by remember { mutableStateOf(false) }
         var isMainDialogVisible by remember { mutableStateOf(false) }
+        var removeCandidateId by remember { mutableStateOf<String?>(null) }
+        var removeCandidateName by remember { mutableStateOf("") }
         
         LaunchedEffect(Unit) {
             viewModel.handle(DeviceViewEvents.OnAppear)
@@ -60,9 +66,17 @@ class DevicesScreen : Screen {
                     verticalArrangement = Arrangement.spacedBy(14.dp)
                 ) {
                     items(devices) { device ->
+                        val memberCount = devices.count { it.status == DeviceStatus.Member || it.status == DeviceStatus.Current }
+                        val canRemove = device.status == DeviceStatus.Member && memberCount > 1
                         DeviceContent(
-                            device,
-                            viewModel.currentDeviceId,
+                            model = device,
+                            currentDeviceId = viewModel.currentDeviceId,
+                            isRemoving = isRemoving,
+                            canRemove = canRemove,
+                            onRemoveClick = {
+                                removeCandidateId = device.id
+                                removeCandidateName = device.deviceName
+                            },
                             onClick = {
                                 if (device.status == DeviceStatus.Pending || device.status == DeviceStatus.Declined) {
                                     viewModel.handle(DeviceViewEvents.SelectDevice(device.id))
@@ -124,6 +138,26 @@ class DevicesScreen : Screen {
                 mainDialogVisibility = { isDialogVisible = it },
                 dialogVisibility = { isDialogVisible = it }
             )
+        }
+
+        if (removeCandidateId != null) {
+            Dialog(
+                onDismissRequest = { if (!isRemoving) removeCandidateId = null },
+                properties = DialogProperties(usePlatformDefaultWidth = false)
+            ) {
+                ui.dialogs.YesNoDialog(
+                    title = "${stringResource(Res.string.removeDeviceConfirmTitle)}\n${stringResource(Res.string.removeDeviceConfirmMessage, removeCandidateName)}",
+                    isVisible = true,
+                    onDismiss = { accepted ->
+                        if (accepted == true && !isRemoving) {
+                            viewModel.handle(DeviceViewEvents.RemoveDevice(removeCandidateId!!))
+                        }
+                        if (!isRemoving) {
+                            removeCandidateId = null
+                        }
+                    }
+                )
+            }
         }
 
     }

--- a/composeApp/src/commonMain/kotlin/ui/scenes/devicesscreen/DevicesScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/ui/scenes/devicesscreen/DevicesScreenViewModel.kt
@@ -46,6 +46,9 @@ class DevicesScreenViewModel(
     private val _currentDeviceId = MutableStateFlow<String?>(null)
     val currentDeviceId: String?
         get() = keyValueStorage.cachedDeviceId
+    
+    private val _isRemoving = MutableStateFlow(false)
+    val isRemoving = _isRemoving.asStateFlow()
 
     val vaultName = vaultStatsProvider.vaultName
     
@@ -90,6 +93,7 @@ class DevicesScreenViewModel(
                 DeviceViewEvents.OnAppear -> loadDevicesList(false)
                 DeviceViewEvents.Accept -> authenticateAndUpdateMembership(true)
                 DeviceViewEvents.Decline -> authenticateAndUpdateMembership(false)
+                is DeviceViewEvents.RemoveDevice -> removeDevice(event.deviceId)
                 is DeviceViewEvents.SelectDevice -> {
                     selectCurrentDevice(event.deviceId)
                     event.deviceId?.let { deviceId ->
@@ -193,6 +197,42 @@ class DevicesScreenViewModel(
         logger.log(LogTag.DevicesVM.Message.SelectDevice, "$deviceId", success = true)
         _currentDeviceId.value = deviceId
     }
+
+    private fun removeDevice(deviceId: String) {
+        viewModelScope.launch {
+            val currentId = keyValueStorage.cachedDeviceId
+            if (deviceId == currentId) {
+                notificationCoordinator.showError(stringProvider.removeDeviceSelfError())
+                return@launch
+            }
+
+            val currentMembers = _devicesList.value.count { it.status == DeviceStatus.Member || it.status == DeviceStatus.Current }
+            if (currentMembers <= 1) {
+                notificationCoordinator.showError(stringProvider.removeDeviceLastMemberError())
+                return@launch
+            }
+
+            _isRemoving.value = true
+            try {
+                val candidate = withContext(Dispatchers.IO) { appManager.getUserDataBy(deviceId) }
+                if (candidate == null) {
+                    notificationCoordinator.showError(stringProvider.removeDeviceGenericError())
+                    return@launch
+                }
+                val result = withContext(Dispatchers.IO) { appManager.updateMember(candidate, UpdateMemberActionModel.Decline.name) }
+                if (result?.success == true) {
+                    notificationCoordinator.showSuccess(stringProvider.removeDeviceSuccess())
+                    _devicesList.value = fetchDevicesList(isSocketAction = false)
+                } else {
+                    notificationCoordinator.showError(result?.error ?: stringProvider.removeDeviceGenericError())
+                }
+            } catch (_: Exception) {
+                notificationCoordinator.showError(stringProvider.removeDeviceGenericError())
+            } finally {
+                _isRemoving.value = false
+            }
+        }
+    }
 }
 
 sealed class DeviceViewEvents : CommonViewModelEventsInterface {
@@ -200,4 +240,5 @@ sealed class DeviceViewEvents : CommonViewModelEventsInterface {
     data object Accept : DeviceViewEvents()
     data object Decline : DeviceViewEvents()
     data class SelectDevice(val deviceId: String?) : DeviceViewEvents()
+    data class RemoveDevice(val deviceId: String) : DeviceViewEvents()
 }

--- a/composeApp/src/commonMain/kotlin/ui/screenContent/DeviceContentCell.kt
+++ b/composeApp/src/commonMain/kotlin/ui/screenContent/DeviceContentCell.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,7 +44,9 @@ import kotlinproject.composeapp.generated.resources.other
 import kotlinproject.composeapp.generated.resources.secret
 import kotlinproject.composeapp.generated.resources.secrets_4
 import kotlinproject.composeapp.generated.resources.secrets_5
+import kotlinproject.composeapp.generated.resources.shield_l1
 import kotlinproject.composeapp.generated.resources.tablet
+import kotlinproject.composeapp.generated.resources.trashbox
 import kotlinproject.composeapp.generated.resources.web
 import models.apiModels.DeviceUiCategory
 import models.appInternalModels.DeviceCellModel
@@ -58,6 +61,9 @@ import org.jetbrains.compose.resources.DrawableResource
 fun DeviceContent(
     model: DeviceCellModel,
     currentDeviceId: String?,
+    isRemoving: Boolean,
+    canRemove: Boolean,
+    onRemoveClick: () -> Unit,
     onClick: ()-> Unit
 ) {
     val effectiveStatus = if (model.id == currentDeviceId) DeviceStatus.Current else model.status
@@ -130,6 +136,24 @@ fun DeviceContent(
                                 fontFamily = FontFamily(Font(Res.font.manrope_regular)),
                                 color = Color(0xFF4E6A88)
                             )
+                        )
+                    }
+                    if (canRemove) {
+                        IconButton(
+                            onClick = onRemoveClick,
+                            enabled = !isRemoving
+                        ) {
+                            Image(
+                                painter = painterResource(Res.drawable.trashbox),
+                                contentDescription = null,
+                                modifier = Modifier.size(28.dp)
+                            )
+                        }
+                    } else {
+                        Image(
+                            painter = painterResource(Res.drawable.shield_l1),
+                            contentDescription = null,
+                            modifier = Modifier.size(28.dp)
                         )
                     }
                     StatusBadge(status = effectiveStatus)

--- a/composeApp/src/commonTest/kotlin/testutils/TestDoubles.kt
+++ b/composeApp/src/commonTest/kotlin/testutils/TestDoubles.kt
@@ -171,6 +171,10 @@ class FakeStringProvider : StringProviderInterface {
     override fun nameOccupiedJoinPrompt() = "join existing vault"
     override fun recoverPendingExists() = "recover pending exists"
     override fun recoverRequestSent() = "recover request sent"
+    override fun removeDeviceSuccess() = "device removed"
+    override fun removeDeviceSelfError() = "self remove denied"
+    override fun removeDeviceLastMemberError() = "last member remove denied"
+    override fun removeDeviceGenericError() = "remove failed"
 }
 
 class FakeBiometricAuthenticator : BiometricAuthenticatorInterface {

--- a/composeApp/src/iosMain/kotlin/core/StringProvider.ios.kt
+++ b/composeApp/src/iosMain/kotlin/core/StringProvider.ios.kt
@@ -37,5 +37,9 @@ class StringProviderIos : StringProviderInterface {
     override fun nameOccupiedJoinPrompt() = s(Res.string.name_occupied_join_prompt)
     override fun recoverPendingExists() = s(Res.string.recoverPendingExists)
     override fun recoverRequestSent() = s(Res.string.recoverRequestSent)
+    override fun removeDeviceSuccess() = s(Res.string.deviceRemovedSuccess)
+    override fun removeDeviceSelfError() = s(Res.string.removeDeviceSelfError)
+    override fun removeDeviceLastMemberError() = s(Res.string.removeDeviceLastMemberError)
+    override fun removeDeviceGenericError() = s(Res.string.removeDeviceGenericError)
 }
 


### PR DESCRIPTION
Implements issue #79 mobile-side device removal flow in Compose/KMP.

What changed:
- Added remove-device orchestration in DevicesScreenViewModel
- Added local guards for self-removal and last-member removal
- Added confirmation dialog wiring from devices screen
- Added row actions (trash for removable, shield for protected)
- Added RU/EN localized strings for removal success/errors/confirmation
- Updated string providers and test double contract

Notes:
- Current core binding does not expose remove_device_from_vault; implementation uses existing membership-decline path as temporary orchestration and is structured for easy swap once core API is available.

Validation:
- ./gradlew build -x test --no-daemon --parallel --console=plain
- ./gradlew test --no-daemon --parallel --console=plain